### PR TITLE
Enable UTF-8 support for movie names

### DIFF
--- a/rcm.py
+++ b/rcm.py
@@ -136,7 +136,7 @@ def api(host, com = "get", args = None ):
             key.update({"tmdbid" : int(args)})
         elif com == "post":
             url += u"?apikey=" + config[u'radarr'][u'api_key']
-            response = requests.post(url, data = args)
+            response = requests.post(url, data = args.encode('utf-8'))
             return response.status_code
     elif host == "TMDB":
         key = {"api_key": config[u'tmdb'][u'api_key']}


### PR DESCRIPTION
When initially scanning my library the script failed on movie names that contained utf-8 chars.
This modification allowed it run through with no further issues.
I am no python dev, if there is a cleaner way please disregard this, and make it so.